### PR TITLE
Simd aarch64 long seq opt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitnuc"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 authors = ["Noam Teyssier <noam.teyssier@arcinstitute.org"]
 repository = "https://github.com/noamteyssier/bitnuc"

--- a/benches/packing_benchmark.rs
+++ b/benches/packing_benchmark.rs
@@ -136,8 +136,10 @@ fn bench_fast_packing_long_sequences(c: &mut Criterion) {
         "simd"
     };
 
-    // Test different sequence lengths
-    for size in [32_000, 64_000, 128_000, 256_000, 512_000].iter() {
+    // Test a wide range of sequence lengths (mostly large ones)
+    for size in &[
+        1, 17, 64, 128, 256, 512, 1024, 32_000, 64_000, 128_000, 256_000, 512_000,
+    ] {
         let seq = generate_sequence(*size);
 
         group.bench_with_input(

--- a/benches/packing_benchmark.rs
+++ b/benches/packing_benchmark.rs
@@ -127,12 +127,36 @@ fn bench_access_patterns(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_fast_packing_long_sequences(c: &mut Criterion) {
+    let mut group = c.benchmark_group("packing");
+
+    let impl_type = if cfg!(feature = "nosimd") {
+        "nosimd"
+    } else {
+        "simd"
+    };
+
+    // Test different sequence lengths
+    for size in [32_000, 64_000, 128_000, 256_000, 512_000].iter() {
+        let seq = generate_sequence(*size);
+
+        group.bench_with_input(
+            BenchmarkId::new(format!("pack_{}", impl_type), size),
+            &seq,
+            |b, seq| b.iter(|| PackedSequence::new(black_box(seq))),
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_packing,
     bench_unpacking,
     bench_roundtrip,
     bench_sequence_patterns,
-    bench_access_patterns
+    bench_access_patterns,
+    bench_fast_packing_long_sequences
 );
 criterion_main!(benches);

--- a/benches/simd_comparison.rs
+++ b/benches/simd_comparison.rs
@@ -1,4 +1,4 @@
-use bitnuc::{as_2bit, from_2bit};
+use bitnuc::{as_2bit, decode, encode_alloc, from_2bit};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 fn generate_sequence(length: usize) -> Vec<u8> {
@@ -29,6 +29,29 @@ fn bench_packing(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_encoding(c: &mut Criterion) {
+    let mut group = c.benchmark_group("packing");
+
+    let impl_type = if cfg!(feature = "nosimd") {
+        "nosimd"
+    } else {
+        "simd"
+    };
+
+    // Test different sequence lengths
+    for size in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024].iter() {
+        let seq = generate_sequence(*size);
+
+        group.bench_with_input(
+            BenchmarkId::new(format!("encoding_{}", impl_type), size),
+            &seq,
+            |b, seq| b.iter(|| encode_alloc(seq).unwrap()),
+        );
+    }
+
+    group.finish();
+}
+
 fn bench_unpacking(c: &mut Criterion) {
     let mut group = c.benchmark_group("unpacking");
 
@@ -53,5 +76,35 @@ fn bench_unpacking(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_packing, bench_unpacking);
+fn bench_decoding(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unpacking");
+
+    let impl_type = if cfg!(feature = "nosimd") {
+        "no_simd"
+    } else {
+        "simd"
+    };
+
+    // Test different sequence lengths
+    for size in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024].iter() {
+        let seq = generate_sequence(*size);
+        let packed = encode_alloc(&seq).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new(format!("decoding_{}", impl_type), size),
+            &packed,
+            |b, packed| b.iter(|| decode(packed, *size, &mut Vec::new()).unwrap()),
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_packing,
+    bench_encoding,
+    bench_unpacking,
+    bench_decoding
+);
 criterion_main!(benches);

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@ pub enum NucleotideError {
         end: usize,
         length: usize,
     },
+    Unsupported,
 }
 
 impl fmt::Display for NucleotideError {
@@ -38,6 +39,7 @@ impl fmt::Display for NucleotideError {
                     start, end, length
                 )
             }
+            NucleotideError::Unsupported => write!(f, "Unsupported architecture"),
         }
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -58,12 +58,6 @@ pub fn encode_alloc(sequence: &[u8]) -> Result<Vec<u64>, NucleotideError> {
 ///
 /// If the sequence cannot be unpacked, an error is returned.
 pub fn decode(ebuf: &[u64], n_bases: usize, dbuf: &mut Vec<u8>) -> Result<(), NucleotideError> {
-    // // If the sequence is large enough and SIMD is supported, use SIMD acceleration
-    // if ebuf.len() > 1_000 && fast_decode(ebuf, n_bases, dbuf).is_ok() {
-    //     return Ok(());
-    // }
-
-    // Otherwise, use the scalar implementation
     from_2bit_multi(ebuf, n_bases, dbuf)
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,8 +4,8 @@ pub mod packing;
 pub mod unpacking;
 
 pub use functions::{hdist, hdist_scalar, split_packed};
-pub use packing::{as_2bit, fast_encode};
-pub use unpacking::{fast_decode, from_2bit, from_2bit_alloc, from_2bit_multi};
+pub use packing::{as_2bit, encode_internal};
+pub use unpacking::{from_2bit, from_2bit_alloc, from_2bit_multi};
 
 use crate::NucleotideError;
 
@@ -20,30 +20,7 @@ use crate::NucleotideError;
 ///
 /// If the sequence cannot be encoded, an error is returned.
 pub fn encode(sequence: &[u8], ebuf: &mut Vec<u64>) -> Result<(), NucleotideError> {
-    // If the sequence is large enough and SIMD is supported, use SIMD acceleration
-    if sequence.len() > 1_000 && fast_encode(sequence, ebuf).is_ok() {
-        return Ok(());
-    }
-
-    // Clear the buffer
-    ebuf.clear();
-
-    // Calculate the number of chunks
-    let n_chunks = sequence.len().div_ceil(32);
-
-    let mut l_bounds = 0;
-    for _ in 0..n_chunks - 1 {
-        let r_bounds = l_bounds + 32;
-        let chunk = &sequence[l_bounds..r_bounds];
-
-        let bits = as_2bit(chunk)?;
-        ebuf.push(bits);
-        l_bounds = r_bounds;
-    }
-
-    let bits = as_2bit(&sequence[l_bounds..])?;
-    ebuf.push(bits);
-
+    encode_internal(sequence, ebuf)?;
     Ok(())
 }
 
@@ -81,10 +58,10 @@ pub fn encode_alloc(sequence: &[u8]) -> Result<Vec<u64>, NucleotideError> {
 ///
 /// If the sequence cannot be unpacked, an error is returned.
 pub fn decode(ebuf: &[u64], n_bases: usize, dbuf: &mut Vec<u8>) -> Result<(), NucleotideError> {
-    // If the sequence is large enough and SIMD is supported, use SIMD acceleration
-    if ebuf.len() > 1_000 && fast_decode(ebuf, n_bases, dbuf).is_ok() {
-        return Ok(());
-    }
+    // // If the sequence is large enough and SIMD is supported, use SIMD acceleration
+    // if ebuf.len() > 1_000 && fast_decode(ebuf, n_bases, dbuf).is_ok() {
+    //     return Ok(());
+    // }
 
     // Otherwise, use the scalar implementation
     from_2bit_multi(ebuf, n_bases, dbuf)

--- a/src/utils/packing/aarch64.rs
+++ b/src/utils/packing/aarch64.rs
@@ -176,7 +176,7 @@ pub unsafe fn encode_nucleotides_simd(
 ) -> Result<(), NucleotideError> {
     // If less than 32 nt, we can with the default method before SIMD overhead
     if input.len() < 32 {
-        let tail = as_2bit(input).unwrap();
+        let tail = as_2bit(input)?;
         output[0] = tail;
         return Ok(());
     }

--- a/src/utils/packing/aarch64.rs
+++ b/src/utils/packing/aarch64.rs
@@ -218,22 +218,6 @@ pub unsafe fn encode_nucleotides_simd(
     Ok(())
 }
 
-// #[inline(always)]
-// pub fn encode_internal(sequence: &[u8]) -> Result<Vec<u64>, NucleotideError> {
-//     // if its less than 32, use the naive method before SIMD overhead
-//     if sequence.len() < 32 {
-//         // we know the vec is only 1 element
-//         let mut output = vec![0u64; 1];
-//         output[0] = as_2bit(sequence)?;
-//         return Ok(output);
-//     }
-
-//     // if its more than 32, use the SIMD method
-//     let mut output = vec![0u64; (sequence.len() + 31) / 32];
-//     unsafe { encode_nucleotides_simd(sequence, &mut output)? };
-//     Ok(output)
-// }
-
 #[inline(always)]
 pub fn encode_internal(sequence: &[u8], ebuf: &mut Vec<u64>) -> Result<(), NucleotideError> {
     if sequence.len() < 32 {

--- a/src/utils/packing/avx.rs
+++ b/src/utils/packing/avx.rs
@@ -126,3 +126,26 @@ pub fn as_2bit(seq: &[u8]) -> Result<u64, NucleotideError> {
 
     Ok(packed)
 }
+
+pub fn encode_internal(sequence: &[u8], ebuf: &mut Vec<u64>) -> Result<(), NucleotideError> {
+    // Clear the buffer
+    ebuf.clear();
+
+    // Calculate the number of chunks
+    let n_chunks = sequence.len().div_ceil(32);
+
+    let mut l_bounds = 0;
+    for _ in 0..n_chunks - 1 {
+        let r_bounds = l_bounds + 32;
+        let chunk = &sequence[l_bounds..r_bounds];
+
+        let bits = as_2bit(chunk)?;
+        ebuf.push(bits);
+        l_bounds = r_bounds;
+    }
+
+    let bits = as_2bit(&sequence[l_bounds..])?;
+    ebuf.push(bits);
+
+    Ok(())
+}

--- a/src/utils/packing/mod.rs
+++ b/src/utils/packing/mod.rs
@@ -109,6 +109,16 @@ pub fn as_2bit(seq: &[u8]) -> Result<u64, NucleotideError> {
     naive::as_2bit(seq)
 }
 
+pub fn fast_encode(seq: &[u8], out: &mut Vec<u64>) -> Result<u64, NucleotideError> {
+    #[cfg(all(target_arch = "aarch64", not(feature = "nosimd")))]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        let _ = aarch64::fast_encode(seq, out);
+        Ok(out.len() as u64)
+    } else {
+        Err(NucleotideError::Unsupported)
+    }
+}
+
 #[cfg(test)]
 mod testing {
     use super::*;

--- a/src/utils/packing/naive.rs
+++ b/src/utils/packing/naive.rs
@@ -18,3 +18,26 @@ pub fn as_2bit(seq: &[u8]) -> Result<u64, NucleotideError> {
     }
     Ok(packed)
 }
+
+pub fn encode_internal(sequence: &[u8], ebuf: &mut Vec<u64>) -> Result<(), NucleotideError> {
+    // Clear the buffer
+    ebuf.clear();
+
+    // Calculate the number of chunks
+    let n_chunks = sequence.len().div_ceil(32);
+
+    let mut l_bounds = 0;
+    for _ in 0..n_chunks - 1 {
+        let r_bounds = l_bounds + 32;
+        let chunk = &sequence[l_bounds..r_bounds];
+
+        let bits = as_2bit(chunk)?;
+        ebuf.push(bits);
+        l_bounds = r_bounds;
+    }
+
+    let bits = as_2bit(&sequence[l_bounds..])?;
+    ebuf.push(bits);
+
+    Ok(())
+}

--- a/src/utils/packing/sse.rs
+++ b/src/utils/packing/sse.rs
@@ -130,3 +130,26 @@ pub fn as_2bit(seq: &[u8]) -> Result<u64, NucleotideError> {
 
     Ok(packed)
 }
+
+pub fn encode_internal(sequence: &[u8], ebuf: &mut Vec<u64>) -> Result<(), NucleotideError> {
+    // Clear the buffer
+    ebuf.clear();
+
+    // Calculate the number of chunks
+    let n_chunks = sequence.len().div_ceil(32);
+
+    let mut l_bounds = 0;
+    for _ in 0..n_chunks - 1 {
+        let r_bounds = l_bounds + 32;
+        let chunk = &sequence[l_bounds..r_bounds];
+
+        let bits = as_2bit(chunk)?;
+        ebuf.push(bits);
+        l_bounds = r_bounds;
+    }
+
+    let bits = as_2bit(&sequence[l_bounds..])?;
+    ebuf.push(bits);
+
+    Ok(())
+}

--- a/src/utils/unpacking/aarch64.rs
+++ b/src/utils/unpacking/aarch64.rs
@@ -111,6 +111,73 @@ pub unsafe fn from_2bit_multi_simd(
     Ok(())
 }
 
+/// Decode 16 packed 2‑bit codes (`u32`) to ASCII (`A`, `C`, `G`, `T`).
+#[inline(always)]
+pub unsafe fn decode_16_nucleotides(encoded: u32, dst: *mut u8) {
+    // 1. Broadcast the word to four lanes
+    let val = vdupq_n_u32(encoded);
+    let mask = vdupq_n_u32(3);
+
+    // 2. Extract 2‑bit fields (negative counts = right shift)
+    #[inline(always)]
+    const fn shv(a: i32, b: i32, c: i32, d: i32) -> int32x4_t {
+        unsafe { core::mem::transmute([a, b, c, d]) }
+    }
+    let c0 = vandq_u32(vshlq_u32(val, shv(0, -2, -4, -6)), mask);
+    let c1 = vandq_u32(vshlq_u32(val, shv(-8, -10, -12, -14)), mask);
+    let c2 = vandq_u32(vshlq_u32(val, shv(-16, -18, -20, -22)), mask);
+    let c3 = vandq_u32(vshlq_u32(val, shv(-24, -26, -28, -30)), mask);
+
+    // 3. Narrow u32 → u8 and assemble 16 indices
+    let idx: uint8x16_t = vcombine_u8(
+        vmovn_u16(vcombine_u16(vmovn_u32(c0), vmovn_u32(c1))),
+        vmovn_u16(vcombine_u16(vmovn_u32(c2), vmovn_u32(c3))),
+    );
+
+    // 4. LUT: 0→A, 1→C, 2→G, 3→T
+    let lut: uint8x16_t = core::mem::transmute([
+        b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T', b'A', b'C', b'G',
+        b'T',
+    ]);
+    let ascii = vqtbl1q_u8(lut, idx);
+
+    // 5. Store
+    vst1q_u8(dst, ascii);
+}
+
+/// Decode a packed 2‑bit stream (`u64` words) back to ASCII nucleotides.
+pub unsafe fn decode_nucleotides_simd(
+    input: &[u64],
+    len: usize,
+    output: &mut [u8],
+) -> Result<(), ()> {
+    if len > output.len() {
+        return Err(());
+    }
+
+    let chunk = 32;
+    let chunks = len / chunk;
+
+    for i in 0..chunks {
+        let w = input.get(i).copied().unwrap_or(0);
+        decode_16_nucleotides(w as u32, output.as_mut_ptr().add(i * chunk));
+        decode_16_nucleotides((w >> 32) as u32, output.as_mut_ptr().add(i * chunk + 16));
+    }
+
+    // Scalar tail
+    let lut = [b'A', b'C', b'G', b'T'];
+    for j in (chunks * chunk)..len {
+        let idx = ((input[j / 32] >> (2 * (j % 32))) & 3) as usize;
+        output[j] = lut[idx];
+    }
+    Ok(())
+}
+
+pub fn fast_decode(enc: &[u64], len: usize, out: &mut Vec<u8>) -> Result<(), ()> {
+    out.resize(len, 0);
+    unsafe { decode_nucleotides_simd(enc, len, out) }
+}
+
 #[cfg(test)]
 mod testing {
     use super::*;

--- a/src/utils/unpacking/mod.rs
+++ b/src/utils/unpacking/mod.rs
@@ -181,6 +181,16 @@ pub fn from_2bit_alloc(packed: u64, expected_size: usize) -> Result<Vec<u8>, Nuc
     Ok(sequence)
 }
 
+pub fn fast_decode(enc: &[u64], len: usize, out: &mut Vec<u8>) -> Result<u64, NucleotideError> {
+    #[cfg(all(target_arch = "aarch64", not(feature = "nosimd")))]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        let _ = aarch64::fast_decode(enc, len, out);
+        Ok(out.len() as u64)
+    } else {
+        Err(NucleotideError::Unsupported)
+    }
+}
+
 #[cfg(test)]
 mod testing {
     use super::*;

--- a/src/utils/unpacking/mod.rs
+++ b/src/utils/unpacking/mod.rs
@@ -181,14 +181,73 @@ pub fn from_2bit_alloc(packed: u64, expected_size: usize) -> Result<Vec<u8>, Nuc
     Ok(sequence)
 }
 
+/// Efficiently decodes multiple 2-bit packed nucleotide sequences back into ASCII.
+///
+/// This is an optimized version of the decoding process that directly writes the
+/// unpacked ASCII nucleotides into a provided output vector. This function is designed for
+/// performance-critical applications that need to process large sequences.
+///
+/// # Arguments
+///
+/// * `enc` - A slice of u64 values containing the 2-bit packed representations
+/// * `len` - The total number of nucleotides to decode
+/// * `out` - A mutable vector that will be filled with the decoded ASCII nucleotides
+///
+/// # Returns
+///
+/// Returns the number of bytes written to the output vector as a `u64`.
+///
+/// # Errors
+///
+/// Returns `NucleotideError::Unsupported` if the current platform or CPU doesn't
+/// support the required SIMD instructions.
+///
+/// # Examples
+///
+/// ```rust
+/// use bitnuc::{as_2bit, fast_decode, NucleotideError};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // Pack a sequence
+/// let packed = as_2bit(b"ACGTACGTACGTACGT")?;
+/// let encoded = vec![packed];
+///
+/// // Fast decode
+/// let mut decoded = Vec::new();
+/// let count = fast_decode(&encoded, 16, &mut decoded)?;
+/// assert_eq!(count, 16); // 16 nucleotides were decoded
+/// assert_eq!(&decoded, b"ACGTACGTACGTACGT");
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Performance
+///
+/// This function leverages platform-specific SIMD instructions when available for
+/// significantly improved performance over the standard decoding method.
 pub fn fast_decode(enc: &[u64], len: usize, out: &mut Vec<u8>) -> Result<u64, NucleotideError> {
     #[cfg(all(target_arch = "aarch64", not(feature = "nosimd")))]
     if std::arch::is_aarch64_feature_detected!("neon") {
-        let _ = aarch64::fast_decode(enc, len, out);
+        let _ = unsafe { aarch64::fast_decode(enc, len, out) };
         Ok(out.len() as u64)
     } else {
         Err(NucleotideError::Unsupported)
     }
+
+    #[cfg(all(target_arch = "x86_64", not(feature = "nosimd")))]
+    if is_x86_feature_detected!("avx2") {
+        // Implementation for AVX2 could be added here
+        return Err(NucleotideError::Unsupported);
+    } else {
+        return Err(NucleotideError::Unsupported);
+    }
+
+    // Default case for unsupported platforms
+    #[cfg(any(
+        feature = "nosimd",
+        all(not(target_arch = "aarch64"), not(target_arch = "x86_64"))
+    ))]
+    Err(NucleotideError::Unsupported)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR is a follow up on: https://github.com/ArcInstitute/binseq/pull/36

This PR adds an optimized implementation for encode and decode that show a meaningful speedup on longer sequences

### Benching (updated)

Bench on long context before changes

```bash
cargo bench
```

output
```
     Running benches/packing_benchmark.rs (target/release/deps/packing_benchmark-f408d428e8068bfb)
packing/pack_simd/1     time:   [15.703 ns 15.718 ns 15.738 ns]
                        change: [-1.5072% -1.1275% -0.7000%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  3 (3.00%) high mild
  13 (13.00%) high severe
packing/pack_simd/17    time:   [24.656 ns 24.736 ns 24.816 ns]
                        change: [+0.1503% +0.6319% +1.1098%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
packing/pack_simd/64    time:   [56.342 ns 56.398 ns 56.455 ns]
                        change: [-1.7254% -1.0753% -0.4449%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  11 (11.00%) high mild
  5 (5.00%) high severe
packing/pack_simd/128   time:   [91.771 ns 91.897 ns 92.035 ns]
                        change: [-0.2002% +0.2245% +0.6713%] (p = 0.28 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
packing/pack_simd/256   time:   [186.01 ns 186.23 ns 186.51 ns]
                        change: [-2.5612% -1.5883% -0.7292%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) high mild
  12 (12.00%) high severe
packing/pack_simd/512   time:   [351.39 ns 351.60 ns 351.85 ns]
                        change: [+0.0867% +0.2888% +0.4804%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
packing/pack_simd/1024  time:   [655.76 ns 656.15 ns 656.57 ns]
                        change: [-0.5243% -0.3303% -0.1318%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low severe
  3 (3.00%) high mild
  8 (8.00%) high severe
packing/pack_simd/32000 time:   [18.049 µs 18.069 µs 18.092 µs]
                        change: [+0.0917% +0.3060% +0.5119%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
packing/pack_simd/64000 time:   [35.746 µs 35.834 µs 35.935 µs]
                        change: [-0.3255% +0.0171% +0.3191%] (p = 0.92 > 0.05)
                        No change in performance detected.
Found 27 outliers among 100 measurements (27.00%)
  10 (10.00%) low mild
  3 (3.00%) high mild
  14 (14.00%) high severe
packing/pack_simd/128000
                        time:   [71.363 µs 71.600 µs 71.956 µs]
                        change: [-0.0679% +0.2348% +0.5526%] (p = 0.15 > 0.05)
                        No change in performance detected.
Found 24 outliers among 100 measurements (24.00%)
  5 (5.00%) low severe
  6 (6.00%) low mild
  3 (3.00%) high mild
  10 (10.00%) high severe
packing/pack_simd/256000
                        time:   [142.73 µs 142.82 µs 142.93 µs]
                        change: [-0.1243% +0.0550% +0.2286%] (p = 0.55 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) high mild
  11 (11.00%) high severe
packing/pack_simd/512000
                        time:   [290.82 µs 291.17 µs 291.50 µs]
                        change: [-0.6153% -0.2769% +0.0337%] (p = 0.10 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

     Running benches/sequence_benchmark.rs (target/release/deps/sequence_benchmark-0883711688bc8d3a)
```

and after 

```bash
cargo bench
```

after

```
     Running benches/packing_benchmark.rs (target/release/deps/packing_benchmark-f408d428e8068bfb)
packing/pack_simd/1     time:   [15.426 ns 15.473 ns 15.529 ns]
                        change: [-2.2511% -1.7766% -1.3426%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe
packing/pack_simd/17    time:   [24.441 ns 24.509 ns 24.601 ns]
                        change: [-0.4958% +0.1656% +0.8013%] (p = 0.61 > 0.05)
                        No change in performance detected.
packing/pack_simd/64    time:   [36.401 ns 36.687 ns 36.917 ns]
                        change: [-35.356% -35.030% -34.740%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) low severe
  2 (2.00%) low mild
  5 (5.00%) high mild
packing/pack_simd/128   time:   [42.206 ns 42.914 ns 43.623 ns]
                        change: [-53.628% -53.150% -52.698%] (p = 0.00 < 0.05)
                        Performance has improved.
packing/pack_simd/256   time:   [60.647 ns 61.015 ns 61.378 ns]
                        change: [-67.200% -67.076% -66.959%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 23 outliers among 100 measurements (23.00%)
  5 (5.00%) low severe
  4 (4.00%) low mild
  12 (12.00%) high mild
  2 (2.00%) high severe
packing/pack_simd/512   time:   [71.757 ns 71.824 ns 71.902 ns]
                        change: [-79.578% -79.539% -79.502%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 33 outliers among 100 measurements (33.00%)
  23 (23.00%) low severe
  2 (2.00%) high mild
  8 (8.00%) high severe
packing/pack_simd/1024  time:   [128.82 ns 128.89 ns 129.00 ns]
                        change: [-80.398% -80.359% -80.320%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low severe
  3 (3.00%) high mild
  11 (11.00%) high severe
packing/pack_simd/32000 time:   [4.1034 µs 4.1156 µs 4.1281 µs]
                        change: [-77.429% -77.351% -77.279%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
packing/pack_simd/64000 time:   [7.5325 µs 7.5491 µs 7.5658 µs]
                        change: [-78.931% -78.859% -78.784%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
packing/pack_simd/128000
                        time:   [14.700 µs 14.708 µs 14.717 µs]
                        change: [-79.468% -79.402% -79.345%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) low mild
  3 (3.00%) high mild
  8 (8.00%) high severe
packing/pack_simd/256000
                        time:   [28.782 µs 28.794 µs 28.809 µs]
                        change: [-79.889% -79.851% -79.815%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) high mild
  9 (9.00%) high severe
packing/pack_simd/512000
                        time:   [57.578 µs 57.703 µs 57.860 µs]
                        change: [-80.215% -80.159% -80.093%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  12 (12.00%) high severe

     Running benches/sequence_benchmark.rs (target/release/deps/sequence_benchmark-0883711688bc8d3a)
```


summary table of the performance improvements shown in the benchmark results

| Sequence Length | Before (ns/µs) | After (ns/µs) | Improvement (%) | Speedup (×) |
| --------------- | -------------- | ------------- | --------------- | ----------- |
| 1               | 15.718 ns      | 15.473 ns     | 1.56%           | 1.02×       |
| 17              | 24.736 ns      | 24.509 ns     | 0.92%           | 1.01×       |
| 64              | 56.398 ns      | 36.687 ns     | 34.95%          | 1.54×       |
| 128             | 91.897 ns      | 42.914 ns     | 53.30%          | 2.14×       |
| 256             | 186.23 ns      | 61.015 ns     | 67.24%          | 3.05×       |
| 512             | 351.60 ns      | 71.824 ns     | 79.57%          | 4.90×       |
| 1,024           | 656.15 ns      | 128.89 ns     | 80.36%          | 5.09×       |
| 32,000          | 18.069 µs      | 4.1156 µs     | 77.23%          | 4.39×       |
| 64,000          | 35.834 µs      | 7.5491 µs     | 78.93%          | 4.75×       |
| 128,000         | 71.600 µs      | 14.708 µs     | 79.46%          | 4.87×       |
| 256,000         | 142.82 µs      | 28.794 µs     | 79.84%          | 4.96×       |
| 512,000         | 291.17 µs      | 57.703 µs     | 80.18%          | 5.05×       |


These changes result in approximately 79-80% performance improvement on the longer sequences

Please let me know if I should make any changes! 🙏